### PR TITLE
Allow have items with '0' and 'false'.

### DIFF
--- a/js/jquery.scombobox.js
+++ b/js/jquery.scombobox.js
@@ -844,7 +844,7 @@
 
     function purifyData(data, debug) {
         for (var i = 0; i < data.length; i++) {
-            if ((!data[i].value || !data[i].text) && !(data[i].hasOwnProperty('separator'))) {
+            if ((data[i].value == undefined || !data[i].text) && !(data[i].hasOwnProperty('separator'))) {
                 data.splice(i, 1);
             }
         }


### PR DESCRIPTION
Sometimes it will be convenient to have '0' and 'false' as key value in combobox. In your case combobox will not show such items.
