### PR TITLE
Fix searching by special regexp symbols

### DIFF
--- a/js/jquery.scombobox.js
+++ b/js/jquery.scombobox.js
@@ -528,7 +528,7 @@
                 if (fullMatch ? text.indexOf(search) >= 0 : text.indexOf(search) == 0) {
                     // check index and show corresponding paragraph
                     var regexFlags = O.filterIgnoreCase ? 'i' : '';
-                    var re = new RegExp(search, fullMatch ? regexFlags + 'g' : regexFlags);
+                    var re = new RegExp(search.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1"), fullMatch ? regexFlags + 'g' : regexFlags);
                     var $ps = $div.children('p:eq(' + $options.index(this) + '):not(' + cp + csep + ', ' + cp + cpheader + ')').show();
                     if (highlight) {
                         $ps.each(function() {


### PR DESCRIPTION
One more fix.
http://jsfiddle.net/N2scs/45/
Try to perform a search by '[', '[60]' or '('. The fix is a quoting special RegExp symbols. 
