### PR TITLE
Reimplement document click listener hookup

### DIFF
--- a/js/jquery.scombobox.js
+++ b/js/jquery.scombobox.js
@@ -44,7 +44,6 @@
         csep = '-separator', cpheader = '-header',
         cddback = '-dropdown-background', cddarr = '-dropdown-arrow',
         cdisabled = '-disabled';
-    //var documentListenerAdded = false;
     function durations(d) {
         return ({
             fast: 200,
@@ -793,14 +792,12 @@
                 $t.data('scrollTop', currentScrollTop);
             }).data('scrollTop', 0);
         }
-        if (!documentListenerAdded) {
-            documentListenerAdded = true;
-            $(document).bind('click.' + pname, function() {
-                $(cp).each(function() {
-                    slide.call($(this).children(cp + clist), 'up');
-                });
-            });
-        }
+
+
+        $(document).bind('click.' + pname, {thisIs: this}, function(e) {
+            slide.call($(e.data.thisIs).children(cp + clist), 'up');
+        });
+
         this.data('listenersAdded', true);
     }
 


### PR DESCRIPTION
I'm trying to use scombobox in a situation where ajax-style communication with the server deletes a control that I've transformed from a regular select into an scombobox, then adds a new select and transforms this into an scombobox. My problem was, when I clicked away from the first instance (e.g. clicked elsewhere on the window) while it was dropped down the scombobox closed up correctly, but once I'd destroyed this instance and created a new one a click-away no longer closed up the new list.

I devised the attached change, which seems to solve it for me. I think it's back compatible, but I'm not set up to do proper regression testing. Please review it, and merge it if you think it won't cause other problems.
