### PR TITLE
Fix list reset when final character is deleted (#40)

### DIFF
--- a/js/jquery.scombobox.js
+++ b/js/jquery.scombobox.js
@@ -502,7 +502,6 @@
             // Some extra cases
             if (!e.ctrlKey && !e.shiftKey && e.which==45) return; //Insert without modifier
             if (e.ctrlKey && e.which==65) return; //Ctrl+A; imperfect because sometimes we release the A *after* the Ctrl
-            if (this.value=='' && (e.which==8 || e.which==46)) return; //Backspace or Delete on empty field
             
             var fullMatch = O.fullMatch, highlight = O.highlight;
             if (fullMatch) {


### PR DESCRIPTION
Broken by merge pull #39 into upstream

Fix means that Delete or Backspace on empty filter field produces unwanted list dropdown, but to suppress this would require complexity, e.g. in keydown handler so that keyup can distinguish between a releasing of Del/Bksp that has just blanked the field (so we do want to drop the list down), versus a releasing of a key that went down when the field was already blank.